### PR TITLE
Rendering the 3D portion of the FOLD format

### DIFF
--- a/main.js
+++ b/main.js
@@ -324,7 +324,6 @@ function main() {
         if (e.button === 0) {
             isCamRotating = true;
         } else if (e.button === 2) {
-            console.log("RMB");
             isCamPanning = true;
         }
     });

--- a/main.js
+++ b/main.js
@@ -1,4 +1,56 @@
-function main() {
+async function main() {
+
+    // frick CORS
+    const fold = {
+        "file_spec": 1,
+        "file_creator": "A text editor",
+        "file_author": "Jason Ku",
+        "file_classes": ["singleModel"],
+        "frame_title": "Three-fold 3D example",
+        "frame_classes": ["foldedForm"],
+        "frame_attributes": ["3D"],
+        "vertices_coords": [
+          [0,1,0],
+          [0,0,1],
+          [0,-1,0],
+          [1,0,0],
+          [0,0,-1],
+          [0,0,-1]
+        ],
+        "faces_vertices": [
+          [0,1,2],
+          [0,2,3],
+          [0,4,1],
+          [1,5,2]
+        ],
+        "edges_vertices": [
+          [0,2],
+          [0,1],
+          [1,2],
+          [2,3],
+          [0,3],
+          [1,4],
+          [1,5],
+          [0,4],
+          [2,5]
+        ],
+        "edges_assignment": [
+          "V",
+          "M",
+          "M",
+          "B",
+          "B",
+          "B",
+          "B",
+          "B",
+          "B"
+        ],
+        "faceOrders": [
+          [2,0,-1],
+          [3,0,-1]
+        ]
+    };
+
     const canvas = document.getElementById("glCanvas");
 
     // working with WebGL context will be for the most part unnecessary as Three.js handles it
@@ -17,19 +69,34 @@ function main() {
     camera.position.setZ(30);
 
     // init our plane shape, make it same proportions as svg
-    let svgElement = document.querySelector("svg");
-    let svgAspect = svgElement.clientHeight / svgElement.clientWidth;
-    const geometry = new THREE.PlaneGeometry(15, 15 * svgAspect);
+    // let svgElement = document.querySelector("svg");
+    // let svgAspect = svgElement.clientHeight / svgElement.clientWidth;
+    // const geometry = new THREE.PlaneGeometry(15, 15 * svgAspect);
 
-    // load textures and set up materials here
-    const frontMaterial = new THREE.MeshBasicMaterial({color: 0x80ff00, side: THREE.FrontSide});
-    const backMaterial = new THREE.MeshBasicMaterial({color: 0xffffff, side: THREE.BackSide});
-    const plane = new THREE.Group();
+    // // load textures and set up materials here
+    // const frontMaterial = new THREE.MeshBasicMaterial({color: 0x80ff00, side: THREE.FrontSide});
+    // const backMaterial = new THREE.MeshBasicMaterial({color: 0xffffff, side: THREE.BackSide});
+    // const plane = new THREE.Group();
 
-    plane.add(new THREE.Mesh(geometry, frontMaterial));
-    plane.add(new THREE.Mesh(geometry, backMaterial));
+    // plane.add(new THREE.Mesh(geometry, frontMaterial));
+    // plane.add(new THREE.Mesh(geometry, backMaterial));
 
+    // scene.add(plane);
+    let triangleGeometry = new THREE.BufferGeometry();
+    // triangleGeometry.vertices = [new THREE.Vector3(2, 1, 0), new THREE.Vector3(1, 3, 0), new THREE.Vector3(3, 4, 0)];
+    // console.log("TEST:", deepArrayConcat([], [1, 2, 2]));
+    let cArray = deepArrayConcat(new Array(), fold["vertices_coords"]);
+    const vertices = new Float32Array(cArray);
+    console.log(cArray);
+    triangleGeometry.setIndex(deepArrayConcat(new Array(), fold["faces_vertices"]));
+    triangleGeometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
+    // triangleGeometry.faces = [new THREE.Face3(0, 1, 2)];
+    let plane = new THREE.Mesh(triangleGeometry, new THREE.MeshBasicMaterial({color: 0x885556, side: THREE.DoubleSide}));
     scene.add(plane);
+
+    const edges = new THREE.EdgesGeometry(triangleGeometry);
+    const lines = new THREE.LineSegments(edges, new THREE.LineBasicMaterial({color: 0xffffff}));
+    scene.add(lines);
 
     let rotationRadius = 30;
 
@@ -40,7 +107,7 @@ function main() {
     let phi = Math.PI / 2;
 
     let isCamRotating = false;
-    let zoomLimit = 10;
+    let zoomLimit = 2;
     // const sensitivityScaleXY = 0.01;
 
     // prevent right clicks from opening the context menu anywhere
@@ -101,6 +168,32 @@ function main() {
 
     function degToRad(degrees) {
         return degrees * (Math.PI / 180);
+    }
+
+    /**
+     * Helper function to cancatenate two arrays even if they have nested arrays inside
+     * @param {Array} array1 The array to be concatenated to
+     * @param {Array} array2 The array to concatenate onto array1
+     */
+    function deepArrayConcat(array1, array2) {
+        console.log(array1, array2);
+        if (array2.some(el => Array.isArray(el))) {
+            console.log("Deep concat needed");
+            array2.forEach(element => {
+                if (Array.isArray(element)) {
+                    array1 = deepArrayConcat(array1, element);
+                } else {
+                    array1 = array1.concat(element);
+                }
+            });
+            console.log("M1:", array1);
+            return array1;
+        } else {
+            console.log("No deep concat");
+            array1 = array1.concat(array2);
+            console.log(array1);
+            return array1;
+        }
     }
 
     // make some spheres to show the camera is orbiting, not just plane rotating

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-async function main() {
+function main() {
 
     // frick CORS
     const fold = {
@@ -290,22 +290,8 @@ async function main() {
 
     camera.position.setZ(30);
 
-    // init our plane shape, make it same proportions as svg
-    // let svgElement = document.querySelector("svg");
-    // let svgAspect = svgElement.clientHeight / svgElement.clientWidth;
-    // const geometry = new THREE.PlaneGeometry(15, 15 * svgAspect);
-
-    // // load textures and set up materials here
-    // const frontMaterial = new THREE.MeshBasicMaterial({color: 0x80ff00, side: THREE.FrontSide});
-    // const backMaterial = new THREE.MeshBasicMaterial({color: 0xffffff, side: THREE.BackSide});
-    // const plane = new THREE.Group();
-
-    // plane.add(new THREE.Mesh(geometry, frontMaterial));
-    // plane.add(new THREE.Mesh(geometry, backMaterial));
-
-    // scene.add(plane);
     let triangleGeometry = new THREE.BufferGeometry();
-    // triangleGeometry.vertices = [new THREE.Vector3(2, 1, 0), new THREE.Vector3(1, 3, 0), new THREE.Vector3(3, 4, 0)];
+
     // concatenating an empty array is a bit of a hack
     let cArray = deepArrayConcat(new Array(), fold["vertices_coords"]);
     const vertices = new Float32Array(cArray);
@@ -315,7 +301,7 @@ async function main() {
     }
     triangleGeometry.setIndex(deepArrayConcat(new Array(), faces));
     triangleGeometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
-    // triangleGeometry.faces = [new THREE.Face3(0, 1, 2)];
+
     let plane = new THREE.Mesh(triangleGeometry, new THREE.MeshBasicMaterial({color: 0x885556, side: THREE.DoubleSide}));
     scene.add(plane);
 
@@ -363,7 +349,7 @@ async function main() {
 
     let restrictionRangeY = 0.05;
 
-    // orbit the camera upon mouse movement in the canvas
+    // orbit the camera upon mouse movement in the canvas, pan if right clicked
     canvas.addEventListener("mousemove", e => {
         if (isCamRotating) {
             theta -= degToRad(e.movementX);
@@ -458,25 +444,12 @@ async function main() {
                 shifted.push(array[i].shift())
                 outArray.push(shifted.slice(-3));
             } else if (len < 3 || len > 4) {
+                // TODO: replace with better alert when frontend is more permanent
                 alert("Polygon rendering encountered unexpected shapes");
             }
         }
         return outArray;
     }
-
-    // make some spheres to show the camera is orbiting, not just plane rotating
-    function createSphere() {
-        const geometry = new THREE.SphereGeometry(3);
-        const material = new THREE.MeshBasicMaterial({color: 0xffffff});
-        const sph = new THREE.Mesh(geometry, material);
-
-        // using three math utils to randomize numbers
-        const [x, y, z] = Array(3).fill().map(() => THREE.MathUtils.randFloatSpread(250));
-        sph.position.set(x, y, z);
-        scene.add(sph);
-    }
-
-    Array(50).fill().forEach(() => createSphere());
 
     animate();
 

--- a/main.js
+++ b/main.js
@@ -108,6 +108,7 @@ async function main() {
 
     let isCamRotating = false;
     let zoomLimit = 2;
+    let zoomMax = 30;
     // const sensitivityScaleXY = 0.01;
 
     // prevent right clicks from opening the context menu anywhere
@@ -150,6 +151,8 @@ async function main() {
         let newZoom = rotationRadius + e.deltaY * 0.1;
         if (newZoom < zoomLimit) {
             rotationRadius = zoomLimit;
+        } else if (newZoom > zoomMax) {
+            rotationRadius = zoomMax;
         } else {
             rotationRadius = newZoom;
         }

--- a/main.js
+++ b/main.js
@@ -3,51 +3,273 @@ async function main() {
     // frick CORS
     const fold = {
         "file_spec": 1,
-        "file_creator": "A text editor",
-        "file_author": "Jason Ku",
+        "file_creator": "Mathematica",
+        "file_author": "Thomas Hull",
         "file_classes": ["singleModel"],
-        "frame_title": "Three-fold 3D example",
+        "frame_title": "Rigidly folded square twist",
         "frame_classes": ["foldedForm"],
         "frame_attributes": ["3D"],
         "vertices_coords": [
-          [0,1,0],
-          [0,0,1],
-          [0,-1,0],
-          [1,0,0],
-          [0,0,-1],
-          [0,0,-1]
+            [
+                0,
+                0,
+                0
+            ],
+            [
+                0.25,
+                0,
+                0
+            ],
+            [
+                0.25,
+                0.5,
+                0
+            ],
+            [
+                0,
+                0.5,
+                0
+            ],
+            [
+                0.466968,
+                0,
+                -0.124197
+            ],
+            [
+                0.966968,
+                0,
+                -0.124197
+            ],
+            [
+                0.966968,
+                0.25,
+                -0.124197
+            ],
+            [
+                0.466968,
+                0.25,
+                -0.124197
+            ],
+            [
+                0.716968,
+                0.354037,
+                0.103128
+            ],
+            [
+                0.966968,
+                0.354037,
+                0.103128
+            ],
+            [
+                0.966968,
+                0.854037,
+                0.103128
+            ],
+            [
+                0.716968,
+                0.854037,
+                0.103128
+            ],
+            [
+                0,
+                0.854037,
+                0.227324
+            ],
+            [
+                0,
+                0.604037,
+                0.227324
+            ],
+            [
+                0.5,
+                0.604037,
+                0.227324
+            ],
+            [
+                0.5,
+                0.854037,
+                0.227324
+            ]
         ],
         "faces_vertices": [
-          [0,1,2],
-          [0,2,3],
-          [0,4,1],
-          [1,5,2]
+            [
+                0,
+                1,
+                2,
+                3
+            ],
+            [
+                1,
+                4,
+                7,
+                2
+            ],
+            [
+                4,
+                5,
+                6,
+                7
+            ],
+            [
+                7,
+                6,
+                9,
+                8
+            ],
+            [
+                8,
+                9,
+                10,
+                11
+            ],
+            [
+                15,
+                14,
+                8,
+                11
+            ],
+            [
+                12,
+                13,
+                14,
+                15
+            ],
+            [
+                3,
+                2,
+                14,
+                13
+            ],
+            [
+                2,
+                7,
+                8,
+                14
+            ]
         ],
         "edges_vertices": [
-          [0,2],
-          [0,1],
-          [1,2],
-          [2,3],
-          [0,3],
-          [1,4],
-          [1,5],
-          [0,4],
-          [2,5]
+            [
+                0,
+                1
+            ],
+            [
+                1,
+                2
+            ],
+            [
+                2,
+                3
+            ],
+            [
+                3,
+                0
+            ],
+            [
+                4,
+                5
+            ],
+            [
+                5,
+                6
+            ],
+            [
+                6,
+                7
+            ],
+            [
+                7,
+                4
+            ],
+            [
+                8,
+                9
+            ],
+            [
+                9,
+                10
+            ],
+            [
+                10,
+                11
+            ],
+            [
+                11,
+                8
+            ],
+            [
+                12,
+                13
+            ],
+            [
+                13,
+                14
+            ],
+            [
+                14,
+                15
+            ],
+            [
+                15,
+                12
+            ],
+            [
+                2,
+                7
+            ],
+            [
+                7,
+                8
+            ],
+            [
+                8,
+                14
+            ],
+            [
+                14,
+                2
+            ],
+            [
+                3,
+                13
+            ],
+            [
+                1,
+                4
+            ],
+            [
+                6,
+                9
+            ],
+            [
+                11,
+                15
+            ]
         ],
         "edges_assignment": [
-          "V",
-          "M",
-          "M",
-          "B",
-          "B",
-          "B",
-          "B",
-          "B",
-          "B"
-        ],
-        "faceOrders": [
-          [2,0,-1],
-          [3,0,-1]
+            "B",
+            "M",
+            "V",
+            "B",
+            "B",
+            "B",
+            "V",
+            "V",
+            "M",
+            "B",
+            "B",
+            "V",
+            "B",
+            "M",
+            "M",
+            "B",
+            "V",
+            "M",
+            "M",
+            "V",
+            "B",
+            "B",
+            "B",
+            "B"
         ]
     };
 
@@ -84,11 +306,14 @@ async function main() {
     // scene.add(plane);
     let triangleGeometry = new THREE.BufferGeometry();
     // triangleGeometry.vertices = [new THREE.Vector3(2, 1, 0), new THREE.Vector3(1, 3, 0), new THREE.Vector3(3, 4, 0)];
-    // console.log("TEST:", deepArrayConcat([], [1, 2, 2]));
+    // concatenating an empty array is a bit of a hack
     let cArray = deepArrayConcat(new Array(), fold["vertices_coords"]);
     const vertices = new Float32Array(cArray);
-    console.log(cArray);
-    triangleGeometry.setIndex(deepArrayConcat(new Array(), fold["faces_vertices"]));
+    let faces = fold["faces_vertices"];
+    if (faces.some(el => el.length > 3)) {
+        faces = polygonToTri(faces);
+    }
+    triangleGeometry.setIndex(deepArrayConcat(new Array(), faces));
     triangleGeometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
     // triangleGeometry.faces = [new THREE.Face3(0, 1, 2)];
     let plane = new THREE.Mesh(triangleGeometry, new THREE.MeshBasicMaterial({color: 0x885556, side: THREE.DoubleSide}));
@@ -177,11 +402,10 @@ async function main() {
      * Helper function to cancatenate two arrays even if they have nested arrays inside
      * @param {Array} array1 The array to be concatenated to
      * @param {Array} array2 The array to concatenate onto array1
+     * @returns {Array} The result of deep concatenation
      */
     function deepArrayConcat(array1, array2) {
-        console.log(array1, array2);
         if (array2.some(el => Array.isArray(el))) {
-            console.log("Deep concat needed");
             array2.forEach(element => {
                 if (Array.isArray(element)) {
                     array1 = deepArrayConcat(array1, element);
@@ -189,14 +413,42 @@ async function main() {
                     array1 = array1.concat(element);
                 }
             });
-            console.log("M1:", array1);
             return array1;
         } else {
-            console.log("No deep concat");
             array1 = array1.concat(array2);
-            console.log(array1);
             return array1;
         }
+    }
+
+    /**
+     * Function to split polygonal faces into triangles for rendering
+     * @param {Array} array A list of faces made by referencing indexed vertices
+     * @returns {Array} The original array modified to have many triangles instead of polygons
+     */
+    function polygonToTri(array) {
+        let outArray = [];
+        for (let i = 0; i < array.length; i++) {
+            let len = array[i].length;
+            if (len === 3) {
+                outArray.push(array[i]);
+            } else if (len === 4) { // unsure about higher polygons so only handle rect
+                // get the last three elements, then get the first three elements
+                outArray.push(array[i].slice(0, 3));
+                /*
+                 * since the face has its vertices listed in a consistent counterclockwise or
+                 * clockwise order, we don't need the first three then last three, we need
+                 * the first three, then the triangle opposite that is formed by the last two
+                 * vertices andt the first one
+                 * this hack does that by moving the first element to the last to slice the same
+                 */
+                let shifted = array[i];
+                shifted.push(array[i].shift())
+                outArray.push(shifted.slice(-3));
+            } else if (len < 3 || len > 4) {
+                alert("Polygon rendering encountered unexpected shapes");
+            }
+        }
+        return outArray;
     }
 
     // make some spheres to show the camera is orbiting, not just plane rotating

--- a/main.js
+++ b/main.js
@@ -295,9 +295,9 @@ function main() {
 
     scene.add(shape);
 
-    // const edges = new THREE.EdgesGeometry(shape);
-    // const lines = new THREE.LineSegments(edges, new THREE.LineBasicMaterial({color: 0xffffff}));
-    // scene.add(lines);
+    const edges = new THREE.EdgesGeometry(shape.geometry);
+    const lines = new THREE.LineSegments(edges, new THREE.LineBasicMaterial({color: 0xffffff}));
+    scene.add(lines);
 
     let rotationRadius = 30;
 
@@ -386,8 +386,9 @@ function main() {
         let triangleGeometry = new THREE.BufferGeometry();
 
         // concatenating an empty array is a bit of a hack
-        let cArray = deepArrayConcat(new Array(), fold["vertices_coords"]);
-        const vertices = new Float32Array(cArray);
+        let vertsArray = deepArrayConcat(new Array(), fold["vertices_coords"]);
+        vertsArray = mathCoordConversion(vertsArray);
+        const vertices = new Float32Array(vertsArray);
         let faces = fold["faces_vertices"];
 
         // check if there are any faces of more than three vertices
@@ -456,6 +457,27 @@ function main() {
             } else if (len < 3 || len > 4) {
                 // TODO: replace with better alert when frontend is more permanent
                 alert("Polygon rendering encountered unexpected shapes");
+            }
+        }
+        return outArray;
+    }
+
+    /**
+     * Helper function to convert from XYZ (FOLD) to XZY (THREE.js) and possibly back as well. Used
+     * on arrays of values every 3 representing one point, like after calling deepArrayConcat() on
+     * the vertices from FOLD
+     * @param {Array} coordsArray An array of coordinates where every 3 values is one point
+     * @returns A converted array where the second and third values of each coord are swapped
+     */
+    function mathCoordConversion(coordsArray) {
+        let outArray = [];
+        for (let i = 0; i < coordsArray.length; i++) {
+            let specialIndex = (i + 1) % 3;
+            if (!(specialIndex === 2)) {
+                outArray.push(coordsArray[i]);
+            }
+            if (specialIndex === 0) {
+                outArray.push(coordsArray[i - 1]);
             }
         }
         return outArray;


### PR DESCRIPTION
Not much to keep in mind here except some of these steps will need to be done backwards in order to save back to FOLD format.

FOLD uses an XYZ coordinate system where Y is up, as seems to be standard in math. THREE uses XZY, where Z is up, which seems to be standard in development.

Camera panning exists now, because not all the shapes are centered, but it is very weird and only works if you do not rotate.
Lots of helper functions got added to convert the FOLD stuff to be compatible with THREE.

Since we might have direct access to the geometry's vertices, it might not be necessary to render each face individually; we know that the vertices are every group of three values in the positions attribute array. Rendering each face as its own geometry might make the implementation more redundant and expensive as every vertex will have to be accessed and saved multiple times to construct the faces.