### PR TITLE
Reworking rendering to fit with what we expect for FOLD files

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,11 +64,7 @@ function render(file) {
         scene.clear();
         let shapes = [];
 
-        let vertex_coords = fold["vertices_coords"];
-        let faces_indexes = fold["faces_vertices"];
-        if (vertex_coords && faces_indexes) {
-            shapes.push(createFaceGeom(vertex_coords, faces_indexes));
-        } else {
+        if (fold["file_frames"]) {
             // assuming one frame is creases and other is 3D folded shape
             for (let i = 0; i < fold["file_frames"].length; i++) {
                 let frame = fold["file_frames"][i];
@@ -95,6 +91,8 @@ function render(file) {
                     }
                 }
             }
+        } else {
+            shapes.push(createFaceGeom(fold["vertices_coords"], fold["faces_vertices"]));
         }
 
         shapes.forEach(shape => {

--- a/main.js
+++ b/main.js
@@ -65,8 +65,9 @@ function render(file) {
         let shapes = [];
 
         let vertex_coords = fold["vertices_coords"];
-        if (vertex_coords) {
-            shapes.push(createFaceGeom(vertex_coords));
+        let faces_indexes = fold["faces_vertices"];
+        if (vertex_coords && faces_indexes) {
+            shapes.push(createFaceGeom(vertex_coords, faces_indexes));
         } else {
             // assuming one frame is creases and other is 3D folded shape
             for (let i = 0; i < fold["file_frames"].length; i++) {


### PR DESCRIPTION
Can now render files that have multiple frames. It only looks for the "foldedForm" class frame and the frame that it inherits from, which appears to be the style that we are working with.

There is also some basic error handling done with alerts, but nothing comprehensive.

Also should support loading multiple files by clearing the scene each time.